### PR TITLE
Add volume_type to volume sourcedict

### DIFF
--- a/lib/Ceilometer/Process.hs
+++ b/lib/Ceilometer/Process.hs
@@ -239,8 +239,11 @@ getSourceMap m@Metric{..} =
         displayName = case H.lookup "display_name" metricMetadata of
             Just (String x) -> [("display_name", x)]
             _               -> []
+        volumeType = case H.lookup "volume_type" metricMetadata of
+            Just (String x) -> [("volume_type", x)]
+            _               -> []
         counter = [("_counter", "1") | metricType == "cumulative"]
-    in H.fromList $ counter <> base <> displayName
+    in H.fromList $ counter <> base <> displayName <> volumeType
 
 -- | Wrapped construction of a SourceDict with logging
 mapToSourceDict :: HashMap Text Text -> IO (Maybe SourceDict)

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -46,7 +46,8 @@ expectedVolumeHashmap = H.fromList
     ("metric_name", "volume.size"),
     ("metric_unit", "GB"),
     ("metric_type", "gauge"),
-    ("display_name", "cathartic")
+    ("display_name", "cathartic"),
+    ("volume_type", "lethargic")
   ]
 
 expectedVolumeSd :: SourceDict


### PR DESCRIPTION
Maps directly to a cinder volume type (uuid). Required for disk-type based
billing (block vs fast).
